### PR TITLE
Three fixes found setting the repo up on a fresh Arch/KDE machine

### DIFF
--- a/bin/project_pwd.zsh
+++ b/bin/project_pwd.zsh
@@ -2,7 +2,7 @@
 # standalone script and also definable function when sourced
 
 script_path="${(%):-%x}"
-config_file="/home/mahdi/.zsh/extra_config.zsh"
+config_file="$HOME/.zsh/extra_config.zsh"
 
 if [[ ! -f "$config_file" ]]; then
   echo "extra_config not found: $config_file" >&2

--- a/mpv/scripts/SimpleBookmark.lua
+++ b/mpv/scripts/SimpleBookmark.lua
@@ -242,6 +242,11 @@ local o = {
 local utils = require 'mp.utils'
 local msg = require 'mp.msg'
 
+-- mpv 0.37 removed utils.shared_script_property_set; user-data replaced it.
+if not utils.shared_script_property_set then
+	utils.shared_script_property_set = function(n, v) mp.set_property('user-data/' .. n, v) end
+end
+
 o.filters_and_sequence = utils.parse_json(o.filters_and_sequence)
 o.keywords_filter_list = utils.parse_json(o.keywords_filter_list)
 o.list_filters_sort = utils.parse_json(o.list_filters_sort)

--- a/mpv/scripts/SimpleHistory.lua
+++ b/mpv/scripts/SimpleHistory.lua
@@ -217,6 +217,11 @@ local o = {
 local utils = require 'mp.utils'
 local msg = require 'mp.msg'
 
+-- mpv 0.37 removed utils.shared_script_property_set; user-data replaced it.
+if not utils.shared_script_property_set then
+	utils.shared_script_property_set = function(n, v) mp.set_property('user-data/' .. n, v) end
+end
+
 o.history_blacklist = utils.parse_json(o.history_blacklist)
 o.history_incognito_mode_keybind = utils.parse_json(o.history_incognito_mode_keybind)
 o.filters_and_sequence = utils.parse_json(o.filters_and_sequence)

--- a/quickshell/pill/Launcher.qml
+++ b/quickshell/pill/Launcher.qml
@@ -333,9 +333,10 @@ Item {
     
         // finance privacy: an open eye normally, a closed eye (accent = "on") while
         // amounts are masked — auto-on during screen shares (see FinanceState).
-        // Hidden unless the Finance feature is enabled (Settings).
+        // Also shown while masking is active with Finance off: a screen share hides
+        // the calendar and org sections too, so the override must stay reachable.
         MSym {
-            visible: root.fin && root.fin.enabled
+            visible: root.fin && (root.fin.enabled || root.fin.privacy)
             icon: root.fin && root.fin.privacy ? "visibility_off" : "visibility"
             size: 18
             fill: root.fin && root.fin.privacy ? 1 : 0

--- a/quickshell/qs-pill-docs.org
+++ b/quickshell/qs-pill-docs.org
@@ -789,7 +789,10 @@ that closes while on, driving =fin.togglePrivacy()= — amounts mask as =••�
 the calendar's finance signals hide (see [[*FinanceState.qml][=FinanceState=]]).
 The eye shows the *effective* privacy state, so it lights up automatically while
 the screen is shared; clicking it then overrides for that share only, and the
-manual choice returns when sharing ends.
+manual choice returns when sharing ends. It is visible when Finance is enabled
+=or= whenever masking is actually in effect (=fin.enabled || fin.privacy=): a
+screen share also hides the calendar and org sections, so with Finance off the
+eye would otherwise be the one override the user cannot reach.
 Code: part of [[file:pill/Launcher.qml][=pill/Launcher.qml=]] (was noweb chunk =launcher-toggles=).
 
 **** Launcher.qml — power buttons


### PR DESCRIPTION
Setting these dotfiles up on a clean Arch + KDE Plasma 6 (Wayland) machine surfaced three unrelated bugs. Each is a separate commit.

### `project_pwd.zsh` reads a hardcoded home directory

`config_file` was pinned to `/home/mahdi/.zsh/extra_config.zsh`, so for any other user the script exits 2 and the starship `custom.project_pwd` segment renders empty. Now resolved from `$HOME`.

### `SimpleHistory` / `SimpleBookmark` fail to load on mpv 0.37+

mpv 0.37 removed `utils.shared_script_property_set`. Both scripts call it at load time, so on current mpv (verified on 0.41) each aborts with:

```
Lua error: SimpleHistory.lua:257: attempt to call field 'shared_script_property_set' (a nil value)
```

Neither history nor bookmarks load at all. Aliased onto the `user-data` property that replaced it, so the existing call sites keep working and the flag stays observable by other scripts. `uosc` already guards this same call, these two never did.

Verified after the change that `user-data/simplehistory-menu-open` and `user-data/simplebookmark-menu-open` are actually set, not merely that the error stopped.

### The privacy eye is unreachable when Finance is disabled

`CalendarMenu`'s `showCal` and the org section both hide under `fin.privacy`, and `FinanceState` forces privacy on for the duration of any screen share. The eye that overrides it was gated on `fin.enabled`.

With the Finance feature off (the default), starting any screen share therefore hides the calendar completely: its grid dots, the event list, and even the empty-state placeholder, with no way to bring it back short of ending the share. This presents as a broken calendar fetch rather than a deliberate mask, which is how I found it: a fully populated 160-event cache with `errors: []` and nothing on screen.

The eye now shows when Finance is enabled **or** whenever masking is actually in effect. Behaviour with Finance on is unchanged. `qs-pill-docs.org` updated to match.

### Testing

`quickshell/pill/check.sh` passes (python, shell, headless `qs` load). mpv scripts verified by loading mpv and reading the properties back. `deploy.sh` deliberately not run.
