### PR TITLE
add -r restart flag to run-pill.sh

### DIFF
--- a/quickshell/pill/run-pill.sh
+++ b/quickshell/pill/run-pill.sh
@@ -9,10 +9,19 @@
 #
 # Usage:  ./run-pill.sh            (runs quickshell/init.qml next to this script)
 #         ./run-pill.sh <args>     (extra args are forwarded to qs)
+#         ./run-pill.sh -r [args]  (kill any running instance of this config,
+#                                   relaunch detached in the background)
 
 set -eu
 
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+if [ "${1:-}" = "-r" ]; then
+    shift
+    qs kill -p "$dir/init.qml" >/dev/null 2>&1 || true
+    setsid -f "$0" "$@" >/dev/null 2>&1
+    exit 0
+fi
 
 # XDG_RUNTIME_DIR is where the wayland socket lives; derive it if absent.
 : "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"

--- a/quickshell/qs-pill-docs.org
+++ b/quickshell/qs-pill-docs.org
@@ -2419,7 +2419,10 @@ Code: part of [[file:pill/init.qml][=pill/init.qml=]] (was noweb chunk =init-clo
 *** Description
 The launch script (=./run-pill.sh=). Qt picks its platform plugin before any QML
 loads, so the Wayland socket and the icon theme (see [[*Look, translucency & icons][§ Look, translucency & icons]])
-have to be resolved here, not in =init.qml=.
+have to be resolved here, not in =init.qml=. =-r= restarts instead of running in
+the foreground: it kills any instance of this config (=qs kill -p=) and
+relaunches the script detached in the background (=setsid -f=), so it's safe to
+bind to a key or call from a terminal you're about to close.
 *** Code
 Code: [[file:pill/run-pill.sh][=pill/run-pill.sh=]]
 


### PR DESCRIPTION
Adds a `-r` flag to `run-pill.sh`: kills any running instance of this config (`qs kill -p`) and relaunches the script detached in the background (`setsid -f`), so it survives closing the terminal and is safe to bind to a key.

Plain invocation is unchanged, and args after `-r` still forward to `qs`. The run-pill.sh section in `qs-pill-docs.org` documents the flag.